### PR TITLE
[add] 为 progress 添加帮助文本

### DIFF
--- a/src/plugins/Core/plugins/progress.py
+++ b/src/plugins/Core/plugins/progress.py
@@ -95,3 +95,21 @@ async def _(bot: Bot, event: MessageEvent, message: Message) -> None:
         ],
         event.user_id,
     )
+
+
+@create_command("progress", {"prog"})
+async def _(bot: Bot, event: MessageEvent, message: Message) -> None:
+    await finish(
+        "currency.wrong_argv",
+        ["progress"],
+        event.user_id
+    )
+
+# [HELPSTART] Version: 2
+# Command: progress
+# Info: 查看本年/月/日的进度
+# Msg: 查看本年进度
+# Usage: progress-year：查看本年进度
+# Usage: progress-month：查看本月进度
+# Usage: progress-day：查看本日进度
+# [HELPEND]


### PR DESCRIPTION
feat: add help text for progress command

Add help text for the "progress" command to provide usage information
for checking the progress of the year, month, and day. This enhancement
improves user experience and facilitates easier command understanding.