### PR TITLE
[add] 添加物品：普通的垃圾

### DIFF
--- a/src/plugins/Core/lang/zh_hans.json
+++ b/src/plugins/Core/lang/zh_hans.json
@@ -317,7 +317,10 @@
 
   "progress.year": "{}年已经过去 {}%",
   "progress.mon": "{}年{}月已经过去 {}%",
-  "progress.day": "{}年{}月{}日已经过去 {}%"
+  "progress.day": "{}年{}月{}日已经过去 {}%",
   
-  
+  "common_rubbish.display_name": "普通的垃圾",
+  "common_rubbish.display_message": "也许正如它的名字一样，非常普通\n\n可能包哈以下物品: \n1. 压缩毛巾\n2. 毛巾\n3. 神秘碎片\n4. 书与笔\n5. 收纳袋",
+  "common_rubbish.use_title": "你打开了 {} 个「普通的垃圾」，获得了以下物品：",
+  "common_rubbish.use_item": "\n{}. {} x{}"
 }

--- a/src/plugins/Core/plugins/etm/bag.py
+++ b/src/plugins/Core/plugins/etm/bag.py
@@ -5,6 +5,8 @@ from nonebot import require
 from . import economy
 from . import data
 
+from . import rubbish
+
 require("nonebot_plugin_apscheduler")
 
 # items.json2items(json.load(open("data/etm/bags.json", encoding="utf-8")))
@@ -96,3 +98,5 @@ def add_item(user_id, item_id, item_count=1, item_data={}):
 async def use_item(user_id, item_pos, argv=""):
     user_id = str(user_id)
     return await bags[user_id][item_pos].on_use(argv)
+
+rubbish.add_item = add_item

--- a/src/plugins/Core/plugins/etm/bag.py
+++ b/src/plugins/Core/plugins/etm/bag.py
@@ -99,4 +99,5 @@ async def use_item(user_id, item_pos, argv=""):
     user_id = str(user_id)
     return await bags[user_id][item_pos].on_use(argv)
 
+
 rubbish.add_item = add_item

--- a/src/plugins/Core/plugins/etm/item.py
+++ b/src/plugins/Core/plugins/etm/item.py
@@ -1,11 +1,13 @@
+from typing import Optional, Type, cast, overload
 from .item_basic_data import BASIC_DATA
+from abc import ABC, abstractmethod
 import traceback
 from .economy import IllegalQuantityException
 from .nbt import NbtDict
 from .._lang import text
 
 
-class Item:
+class Item(ABC):
     def __init__(self, count, data, user_id):
         self.count = count
         self.item_id = ""  # dice"
@@ -13,7 +15,7 @@ class Item:
         # 初始化
         self.on_register()
         # 设置 NBT
-        self.data: NbtDict = BASIC_DATA.copy()  # type: ignore
+        self.data = BASIC_DATA.copy()  # type: ignore
         self.data.update(self.basic_data)
         self.data.update(data)
         self.user_id = user_id
@@ -25,14 +27,41 @@ class Item:
             except:
                 pass
 
+    @overload
+    def setup_basic_data(
+        self,
+        display_name: Optional[str] = None,
+        display_message: Optional[str] = None,
+        price: Optional[int] = None,
+        maximum_stack: Optional[int] = None,
+        useable: Optional[bool] = None,
+        can_be_sold: Optional[bool] = None,
+        **params
+    ) -> None:
+        ...
+
+    def setup_basic_data(self, *args, **params) -> None:
+        self.basic_data = params
+        
+
+    @abstractmethod
     def on_register(self):
         ...
 
+    @abstractmethod
     def _after_register(self):
         ...
 
+    @abstractmethod
     def use_item(self):
         ...
+
+    @abstractmethod
+    async def async_use(self, arg):
+        raise NotImplementedError
+
+    def text(self, key: str, _format: list = []) -> str:
+        return text(f"{self.item_id}.{key}", _format, self.user_id)
 
     async def on_use(self, arg):
         if not self.data["useable"]:
@@ -41,7 +70,7 @@ class Item:
             return (await self.async_use(arg)) or [
                 text("currency.ok", [], self.user_id)
             ]
-        except AttributeError:
+        except NotImplementedError:
             return (self.use(arg)) or [text("currency.ok", [], self.user_id)]
 
     def use(self, args):

--- a/src/plugins/Core/plugins/etm/item.py
+++ b/src/plugins/Core/plugins/etm/item.py
@@ -11,6 +11,7 @@ class Item(ABC):
     def __init__(self, count, data, user_id):
         self.count = count
         self.item_id = ""  # dice"
+        self.user_id = user_id
         self.basic_data = {}  # type: ignore
         # 初始化
         self.on_register()
@@ -18,7 +19,6 @@ class Item(ABC):
         self.data = BASIC_DATA.copy()  # type: ignore
         self.data.update(self.basic_data)
         self.data.update(data)
-        self.user_id = user_id
         self._after_register()
 
         for key in list(self.data.keys()):
@@ -47,15 +47,15 @@ class Item(ABC):
     def on_register(self):
         ...
 
-    @abstractmethod
+    # @abstractmethod
     def _after_register(self):
         ...
 
-    @abstractmethod
+    # @abstractmethod
     def use_item(self):
         ...
 
-    @abstractmethod
+    # @abstractmethod
     async def async_use(self, arg):
         raise NotImplementedError
 

--- a/src/plugins/Core/plugins/etm/item.py
+++ b/src/plugins/Core/plugins/etm/item.py
@@ -36,13 +36,12 @@ class Item(ABC):
         maximum_stack: Optional[int] = None,
         useable: Optional[bool] = None,
         can_be_sold: Optional[bool] = None,
-        **params
+        **params,
     ) -> None:
         ...
 
     def setup_basic_data(self, *args, **params) -> None:
         self.basic_data = params
-        
 
     @abstractmethod
     def on_register(self):

--- a/src/plugins/Core/plugins/etm/item_list.py
+++ b/src/plugins/Core/plugins/etm/item_list.py
@@ -1,6 +1,7 @@
 from .dice import Dice
 from .auto_sign_coupon import AutoSignCoupon, AutoSignCouponActived
 from .talisman import Talisman
+from .rubbish import CommonRubbish
 from .book_and_quill import BookAndQuill
 from .pawcoin import PawCoin
 from .pouch import Pouch
@@ -17,6 +18,7 @@ ITEMS = {
     "book_and_quill": BookAndQuill,
     "talisman": Talisman,
     "pouch": Pouch,
+    "common_rubbish": CommonRubbish,
     "archfiend_dice": ArchfiendDice,
     "towel.zip": TowelZip,
     "towel": Towel,

--- a/src/plugins/Core/plugins/etm/items.py
+++ b/src/plugins/Core/plugins/etm/items.py
@@ -1,6 +1,8 @@
-from .item_list import ITEMS
 from . import mystery_box
 from .item import Item
+from .item_list import ITEMS
+from . import rubbish
+
 
 
 def json2items(items, user_id=None) -> list[Item]:
@@ -9,5 +11,5 @@ def json2items(items, user_id=None) -> list[Item]:
         item_list.append((ITEMS[item["id"]](item["count"], item["data"], user_id)))
     return item_list
 
-
+rubbish.json2items = json2items
 mystery_box.json2items = json2items

--- a/src/plugins/Core/plugins/etm/items.py
+++ b/src/plugins/Core/plugins/etm/items.py
@@ -4,12 +4,12 @@ from .item_list import ITEMS
 from . import rubbish
 
 
-
 def json2items(items, user_id=None) -> list[Item]:
     item_list = []
     for item in items:
         item_list.append((ITEMS[item["id"]](item["count"], item["data"], user_id)))
     return item_list
+
 
 rubbish.json2items = json2items
 mystery_box.json2items = json2items

--- a/src/plugins/Core/plugins/etm/merger.py
+++ b/src/plugins/Core/plugins/etm/merger.py
@@ -10,10 +10,16 @@ def merge_item_list(original_item_list: list[Item]) -> list[Item]:
                 and item2.data == item.data
                 and item2.count < item2.data["maximum_stack"]
             ):
-                item.count -= (count := item2.data["maximum_stack"] - item2.count)
+                count = min(item2.data["maximum_stack"] - item2.count, item.count)
+                item.count -= count
                 item2.count += count
-                if item.count == 0:
-                    break
+            if item.count == 0:
+                break
         else:
-            item_list.append(item)
+            if item.count <= item.data["maximum_stack"]:
+                item_list.append(item)
+            else:
+                count = item.count
+                item.count = 1
+                item_list += merge_item_list([item for _ in range(count)])
     return item_list

--- a/src/plugins/Core/plugins/etm/merger.py
+++ b/src/plugins/Core/plugins/etm/merger.py
@@ -1,0 +1,14 @@
+from .item import Item
+
+def merge_item_list(original_item_list: list[Item]) -> list[Item]:
+    item_list: list[Item] = []
+    for item in original_item_list:
+        for item2 in item_list:
+            if item2.item_id == item.item_id and item2.data == item.data and item2.count < item2.data["maximum_stack"]:
+                item.count -= (count := item2.data["maximum_stack"] - item2.count)
+                item2.count += count
+                if item.count == 0:
+                    break
+        else:
+            item_list.append(item)
+    return item_list

--- a/src/plugins/Core/plugins/etm/merger.py
+++ b/src/plugins/Core/plugins/etm/merger.py
@@ -1,10 +1,15 @@
 from .item import Item
 
+
 def merge_item_list(original_item_list: list[Item]) -> list[Item]:
     item_list: list[Item] = []
     for item in original_item_list:
         for item2 in item_list:
-            if item2.item_id == item.item_id and item2.data == item.data and item2.count < item2.data["maximum_stack"]:
+            if (
+                item2.item_id == item.item_id
+                and item2.data == item.data
+                and item2.count < item2.data["maximum_stack"]
+            ):
                 item.count -= (count := item2.data["maximum_stack"] - item2.count)
                 item2.count += count
                 if item.count == 0:

--- a/src/plugins/Core/plugins/etm/mystery_box.py
+++ b/src/plugins/Core/plugins/etm/mystery_box.py
@@ -70,31 +70,18 @@ class MysteryBoxLevel1(Item):
                 {"item_id": "dice", "count": [5, 16]},
                 {"item_id": "mysterious_shard", "count": [5, 30]},
                 {"item_id": "pawcoin", "count": [2, 15]},
-                {"item_id": "towel", "count": [1, 16]},
-                {"item_id": "book_and_quill", "count": [1, 1]},
-                {"item_id": "pouch", "count": [1, 1]},
+                {"item_id": "common_rubbish", "count": [1, 10]},
                 {"item_id": "vimcoin", "count": [5, 20]},
             ],
             "rare": [
                 {"item_id": "vimcoin", "count": [15, 40]},
                 {"item_id": "mysterious_shard", "count": [10, 35]},
-                {"item_id": "towel.zip", "count": [1, 5]},
-                {"item_id": "auto_sign_coupon", "count": [1, 5]},
-                {
-                    "item_id": "weapons",
-                    "count": [1, 1],
-                    "data": {"kit": "leather_case"},
-                },
+                {"item_id": "common_rubbish", "count": [5, 10]},
+                {"item_id": "auto_sign_coupon", "count": [1, 5]}
             ],
             "legend": [
                 {"item_id": "mysterybox_lv1", "count": [1, 2]},
-                {"item_id": "talisman", "count": [1, 4]},
-                {
-                    "item_id": "weapons",
-                    "count": [1, 1],
-                    "data": {"kit": "scrorching_sun_phantom"},
-                },
-                {"item_id": "ball", "count": [1, 1], "data": {"kit": "leather_case"}},
+                {"item_id": "talisman", "count": [1, 4]}
             ],
         }
 

--- a/src/plugins/Core/plugins/etm/mystery_box.py
+++ b/src/plugins/Core/plugins/etm/mystery_box.py
@@ -77,11 +77,11 @@ class MysteryBoxLevel1(Item):
                 {"item_id": "vimcoin", "count": [15, 40]},
                 {"item_id": "mysterious_shard", "count": [10, 35]},
                 {"item_id": "common_rubbish", "count": [5, 10]},
-                {"item_id": "auto_sign_coupon", "count": [1, 5]}
+                {"item_id": "auto_sign_coupon", "count": [1, 5]},
             ],
             "legend": [
                 {"item_id": "mysterybox_lv1", "count": [1, 2]},
-                {"item_id": "talisman", "count": [1, 4]}
+                {"item_id": "talisman", "count": [1, 4]},
             ],
         }
 

--- a/src/plugins/Core/plugins/etm/rubbish.py
+++ b/src/plugins/Core/plugins/etm/rubbish.py
@@ -1,9 +1,13 @@
 from typing import Any
-from .items import json2items
-from .bag import add_item
 from .merger import merge_item_list
 from .item import Item
 import random
+
+def json2items(items, user_id=None):
+    ...
+
+def add_item(user_id, item_id, item_count=1, item_data={}):
+    ...
 
 
 class CommonRubbish(Item):
@@ -21,7 +25,7 @@ class CommonRubbish(Item):
         return self.data.get(
             "items",
             [
-                {"item_id": item_id, "count": random.randint(1, 5), "data": {}}
+                {"id": item_id, "count": random.randint(1, 5), "data": {}}
                 for item_id in random.choices(self.ITEM_ID_LIST, k=2)
             ],
         )

--- a/src/plugins/Core/plugins/etm/rubbish.py
+++ b/src/plugins/Core/plugins/etm/rubbish.py
@@ -1,0 +1,51 @@
+from typing import Any
+from items import json2items
+from .bag import add_item
+from .merger import merge_item_list
+from .item import Item
+import random
+
+
+class CommonRubbish(Item):
+    ITEM_ID_LIST = ["pouch", "towel.zip", "towel", "mysterious_shard", "book_and_quill"]
+
+    def on_register(self):
+        self.item_id = "common_rubbish"
+        self.setup_basic_data(
+            display_name=self.text("display_name"),
+            display_message=self.text("display_message"),
+            price=10
+        )
+    
+    def get_items(self) -> list[dict[str,Any]]:
+        return self.data.get("items", [{
+            "item_id": item_id,
+            "count": random.randint(1, 5),
+            "data": {}
+        } for item_id in random.choices(self.ITEM_ID_LIST, k=2)])
+
+    def use(self, args):
+        try:
+            count = int(args)
+        except BaseException:
+            count = 1
+        count = min(count, self.count)
+        
+        items = [
+            item_list for item_list in self.get_items() for _ in range(count)
+        ]
+        self.count -= count
+
+        items = merge_item_list(json2items(items))
+        message = self.text("use_title", [count])
+        length = 1
+        for item in items:
+            add_item(
+                self.user_id,
+                item.item_id,
+                item.count,
+                item.data
+            )
+            message += self.text("use_item", [length, item.item_id, item.count])
+            length += 1
+        return [message]

--- a/src/plugins/Core/plugins/etm/rubbish.py
+++ b/src/plugins/Core/plugins/etm/rubbish.py
@@ -14,15 +14,17 @@ class CommonRubbish(Item):
         self.setup_basic_data(
             display_name=self.text("display_name"),
             display_message=self.text("display_message"),
-            price=10
+            price=10,
         )
-    
-    def get_items(self) -> list[dict[str,Any]]:
-        return self.data.get("items", [{
-            "item_id": item_id,
-            "count": random.randint(1, 5),
-            "data": {}
-        } for item_id in random.choices(self.ITEM_ID_LIST, k=2)])
+
+    def get_items(self) -> list[dict[str, Any]]:
+        return self.data.get(
+            "items",
+            [
+                {"item_id": item_id, "count": random.randint(1, 5), "data": {}}
+                for item_id in random.choices(self.ITEM_ID_LIST, k=2)
+            ],
+        )
 
     def use(self, args):
         try:
@@ -30,22 +32,15 @@ class CommonRubbish(Item):
         except BaseException:
             count = 1
         count = min(count, self.count)
-        
-        items = [
-            item_list for item_list in self.get_items() for _ in range(count)
-        ]
+
+        items = [item_list for item_list in self.get_items() for _ in range(count)]
         self.count -= count
 
         items = merge_item_list(json2items(items))
         message = self.text("use_title", [count])
         length = 1
         for item in items:
-            add_item(
-                self.user_id,
-                item.item_id,
-                item.count,
-                item.data
-            )
+            add_item(self.user_id, item.item_id, item.count, item.data)
             message += self.text("use_item", [length, item.item_id, item.count])
             length += 1
         return [message]

--- a/src/plugins/Core/plugins/etm/rubbish.py
+++ b/src/plugins/Core/plugins/etm/rubbish.py
@@ -1,5 +1,5 @@
 from typing import Any
-from items import json2items
+from .items import json2items
 from .bag import add_item
 from .merger import merge_item_list
 from .item import Item

--- a/src/plugins/Core/plugins/etm/rubbish.py
+++ b/src/plugins/Core/plugins/etm/rubbish.py
@@ -3,8 +3,10 @@ from .merger import merge_item_list
 from .item import Item
 import random
 
+
 def json2items(items, user_id=None):
     ...
+
 
 def add_item(user_id, item_id, item_count=1, item_data={}):
     ...


### PR DESCRIPTION
Add item: Common Rubbish

Introduce a new item "Common Rubbish" with associated display messages
and item usage details. This change involves creating a new class for
"Common Rubbish" and adding it to the item list. The new item comes with
setup and usage methods. This addition addresses the need to expand the
range of available in-game items. No issues fixed.