### PR TITLE
[fix] fix a bug

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,7 +3,7 @@ name: "Auto Merge PR"
 on:
   pull_request:
     types:
-      - open
+      - opened
       - ready_for_review
 
 jobs:


### PR DESCRIPTION
Fix PR triggering condition in auto-merge workflow

Adjusted PR trigger condition from "open" to "opened" to fix a bug preventing automatic PR merging. This change ensures that the workflow correctly triggers for newly opened pull requests. No issue references.