### PR TITLE
修复 Preview 重复响应的问题

### DIFF
--- a/src/plugins/Core/plugins/preview.py
+++ b/src/plugins/Core/plugins/preview.py
@@ -138,6 +138,8 @@ async def _(bot: Bot, event: GroupMessageEvent, message: Message) -> None:
 async def _(event: GroupMessageEvent, matcher: Matcher = Matcher()) -> None:
     if not Json("preview.auto_groups.json")[str(event.group_id)]:
         return
+    if event.get_plaintext()[1:].startswith("preview"):
+        return
     match = re.search("(https?|ftp)://[^\s/$.?#].[^\s]*", event.get_plaintext())
     if match is None:
         return


### PR DESCRIPTION
避免生成“preview”命令的预览回复

这个提交更改修复了一个问题，即使在收到以“preview”开头的消息时，机器人也不会发送预览消息。这样可以避免被动回复，更有效地使用资源，同时提高了用户的体验。

#500