### PR TITLE
[add] 添加子命令: `reply clone` (#441)

### DIFF
--- a/src/plugins/Core/lang/zh_hans.json
+++ b/src/plugins/Core/lang/zh_hans.json
@@ -324,6 +324,7 @@
 
   "bots.message_from": "[来自 {}]:\n",
   "bots.waiting_node": "正在拉取信息, 请稍候 ...",
+  "reply.clone_successful": "[SR] 已成功克隆 {} 条数据",
 
   "su.__base__": "[SU] {}",
   "su.need_argv": "错误: 需要参数",

--- a/src/plugins/Core/plugins/smart_reply.py
+++ b/src/plugins/Core/plugins/smart_reply.py
@@ -323,6 +323,18 @@ async def handle_reply(
                 [fork_reply_data(get_rule_data(int(argv[1]), argv[2]), event.group_id)],
                 event.user_id,
             )
+        
+        elif argv[0] in ["clone", "克隆"]:
+            for rule_id in get_rules(group_id := int(argv[1])):
+                rule: dict = get_rule_data(group_id, rule_id)
+                await create_matcher(
+                    event.get_user_id(),
+                    event.group_id,
+                    rule["match"]["type"],
+                    rule["match"]["text"],
+                    rule["reply"]
+                )
+            await finish("reply.clone_successful", [len(get_rules(int(argv[1])))], event.user_id)
 
         else:
             await finish("reply.need_argv", [], event.user_id)

--- a/src/plugins/Core/plugins/smart_reply.py
+++ b/src/plugins/Core/plugins/smart_reply.py
@@ -40,7 +40,11 @@ sent_messages = []
 
 def get_rules(group_id: int):
     try:
-        return os.listdir(f"data/reply/g{group_id}/")
+        file_list = os.listdir(f"data/reply/g{group_id}/")
+        rule_list = []
+        for file in file_list:
+            rule_list.append(file[:-5])
+        return rule_list
     except OSError:
         return []
 
@@ -90,8 +94,7 @@ def get_rule_reply(rule_id: str, group_id: int):
 async def match_rules(bot: Bot, event: GroupMessageEvent):
     global sent_messages
     message = str(event.get_message())
-    for _rule_id in get_rules(event.group_id):
-        rule_id = _rule_id.replace(".json", "")
+    for rule_id in get_rules(event.group_id):
         if is_matched_rule(rule_id, event.group_id, message):
             sent_messages.append(
                 {
@@ -327,6 +330,7 @@ async def handle_reply(
         elif argv[0] in ["clone", "克隆"]:
             for rule_id in get_rules(group_id := int(argv[1])):
                 rule: dict = get_rule_data(group_id, rule_id)
+                print(rule_id, group_id, rule)
                 await create_matcher(
                     event.get_user_id(),
                     event.group_id,

--- a/src/plugins/Core/plugins/smart_reply.py
+++ b/src/plugins/Core/plugins/smart_reply.py
@@ -323,7 +323,7 @@ async def handle_reply(
                 [fork_reply_data(get_rule_data(int(argv[1]), argv[2]), event.group_id)],
                 event.user_id,
             )
-        
+
         elif argv[0] in ["clone", "克隆"]:
             for rule_id in get_rules(group_id := int(argv[1])):
                 rule: dict = get_rule_data(group_id, rule_id)
@@ -332,9 +332,11 @@ async def handle_reply(
                     event.group_id,
                     rule["match"]["type"],
                     rule["match"]["text"],
-                    rule["reply"]
+                    rule["reply"],
                 )
-            await finish("reply.clone_successful", [len(get_rules(int(argv[1])))], event.user_id)
+            await finish(
+                "reply.clone_successful", [len(get_rules(int(argv[1])))], event.user_id
+            )
 
         else:
             await finish("reply.need_argv", [], event.user_id)


### PR DESCRIPTION
feat(lang): 添加回复克隆子命令

该提交添加了一个新的回复克隆子命令，用于在聊天群组中克隆多个规则的回复。该功能的目的是提供一种批量克隆规则的便捷方法，以提高用户对话中快速回复的效率。使用新的子命令`reply clone`（或`回复克隆`）和规则群组ID作为参数，用户可以复制指定群组中的所有规则的回复内容，使其在其他群组中可用。这个新功能为用户提供了更高的灵活性和操作便利性，并使规则的复制和管理更加简单。

#441