### PR TITLE
添加命令给指定用户添加债务

### DIFF
--- a/src/plugins/Core/plugins/bank.py
+++ b/src/plugins/Core/plugins/bank.py
@@ -116,24 +116,21 @@ async def bank(event: MessageEvent, message: Message = CommandArg()):
     except BaseException:
         await _error.report(traceback.format_exc(), bank_command)
 
+
 @create_superuser_command("bank")
 async def _(bot: Bot, event: MessageEvent, message: Message) -> None:
     argv: list[str] = str(message).split(" ")
     user_id: str = argv[1].replace("[CQ:at,qq=", "").replace("]", "")
     match argv[0]:
         case "add":
-            data.bank_lead_data[user_id].append({"money": int(argv[2]), "time": time.time()})
+            data.bank_lead_data[user_id].append(
+                {"money": int(argv[2]), "time": time.time()}
+            )
         case "give":
-            data.bank_lead_data[user_id].append({"money": int(argv[2]), "time": time.time()})
+            data.bank_lead_data[user_id].append(
+                {"money": int(argv[2]), "time": time.time()}
+            )
             economy.add_vi(user_id, int(argv[2]))
         case _:
-            await finish(
-                "su.unknown_argv",
-                [argv[1]],
-                event.user_id
-            )
-    await finish(
-        "currency.ok",
-        [],
-        event.user_id
-    )
+            await finish("su.unknown_argv", [argv[1]], event.user_id)
+    await finish("currency.ok", [], event.user_id)

--- a/src/plugins/Core/plugins/bank.py
+++ b/src/plugins/Core/plugins/bank.py
@@ -1,6 +1,7 @@
 from nonebot.adapters.onebot.v11 import MessageEvent
 from nonebot.adapters.onebot.v11 import Message
 from nonebot.params import CommandArg
+from ._utils import *
 from . import _error
 from .etm import economy, data, user, exp
 from . import _lang
@@ -8,6 +9,7 @@ import time
 from nonebot import on_command
 import json
 import traceback
+from .su import create_superuser_command
 
 CONFIG = json.load(open("data/bank.config.json", encoding="utf-8"))
 interest_rate = CONFIG["interest_rate"]
@@ -113,3 +115,25 @@ async def bank(event: MessageEvent, message: Message = CommandArg()):
                 await bank_command.finish(_lang.text("bank.usage", [], user_id))
     except BaseException:
         await _error.report(traceback.format_exc(), bank_command)
+
+@create_superuser_command("bank")
+async def _(bot: Bot, event: MessageEvent, message: Message) -> None:
+    argv: list[str] = str(message).split(" ")
+    user_id: str = argv[1].replace("[CQ:at,qq=", "").replace("]", "")
+    match argv[0]:
+        case "add":
+            data.bank_lead_data[user_id].append({"money": int(argv[2]), "time": time.time()})
+        case "give":
+            data.bank_lead_data[user_id].append({"money": int(argv[2]), "time": time.time()})
+            economy.add_vi(user_id, int(argv[2]))
+        case _:
+            await finish(
+                "su.unknown_argv",
+                [argv[1]],
+                event.user_id
+            )
+    await finish(
+        "currency.ok",
+        [],
+        event.user_id
+    )


### PR DESCRIPTION
新增子命令：`su give` & `su add`

本次提交新增两个子命令：`su give`和`su add`。

这些子命令允许管理员给用户添加债务

#283