### PR TITLE
回复添加回声洞

### DIFF
--- a/src/plugins/Core/plugins/cave.py
+++ b/src/plugins/Core/plugins/cave.py
@@ -319,8 +319,9 @@ BANNED_CQ_CODE: list[str] = [
     "[CQ:share",
     "[CQ:contact",
     "[CQ:location",
-    "[CQ:forward"
+    "[CQ:forward",
 ]
+
 
 @on_command("cave-a").handle()
 async def cave_add_handler(
@@ -328,7 +329,13 @@ async def cave_add_handler(
 ):
     global cave_confirm
     try:
-        if (not argument) and event.reply and all([keyword not in str(event.reply.message) for keyword in BANNED_CQ_CODE]):
+        if (
+            (not argument)
+            and event.reply
+            and all(
+                [keyword not in str(event.reply.message) for keyword in BANNED_CQ_CODE]
+            )
+        ):
             message = event.reply.message
         else:
             message = argument

--- a/src/plugins/Core/plugins/cave.py
+++ b/src/plugins/Core/plugins/cave.py
@@ -308,12 +308,30 @@ def check_text_similarity(text: str) -> tuple[dict, float] | None:
     return None
 
 
+BANNED_CQ_CODE: list[str] = [
+    "[CQ:json",
+    "[CQ:mface",
+    "[CQ:xml",
+    "[CQ:record",
+    "[CQ:video",
+    "[CQ:rps",
+    "[CQ:dice",
+    "[CQ:share",
+    "[CQ:contact",
+    "[CQ:location",
+    "[CQ:forward"
+]
+
 @on_command("cave-a").handle()
 async def cave_add_handler(
-    cave: Matcher, bot: Bot, event: GroupMessageEvent, message: Message = CommandArg()
+    cave: Matcher, bot: Bot, event: GroupMessageEvent, argument: Message = CommandArg()
 ):
     global cave_confirm
     try:
+        if (not argument) and event.reply and all([keyword not in str(event.reply.message) for keyword in BANNED_CQ_CODE]):
+            message = event.reply.message
+        else:
+            message = argument
         await showEula(event.get_user_id())
 
         data = json.load(open("data/cave.data.json", encoding="utf-8"))


### PR DESCRIPTION
添加了对回声洞回复的支持，允许用户通过回复消息添加回声洞。

同时，考虑了回复的情况以及一些特定的被禁止的消息类型。这些禁止的消息类型包括 `[CQ:json`、`[CQ:mface`、`[CQ:xml` 等。

如果没有传入回复或者回复的消息中不包含这些禁止的消息类型，我们将使用传入的参数作为回声的消息。本次改动可以让机器人能够更加灵活地进行回声洞回复。 

#476