### PR TITLE
禁止用户访问 `file` 协议内容

### DIFF
--- a/src/plugins/Core/lang/zh_hans.json
+++ b/src/plugins/Core/lang/zh_hans.json
@@ -336,5 +336,6 @@
   "email.no_data": "无内容",
   "sign.returning_email_subject": "欢迎回归！",
   "sign.returning_email_message": " 喵喵, 你回来啦! XDbot 在这里等得不耐烦了呢! \n\nXDbot 为主人准备了一个的回归礼包喵, 记得来拿喵! \n\n记得, XDbot 可是一直在这里等着你喵!",
-  "preview.nsfw": "失败: 检测到不安全内容\n审核信息: {}-{}%"
+  "preview.nsfw": "失败: 检测到不安全内容\n审核信息: {}-{}%",
+  "preview.access_denied": "失败：拒绝访问"
 }

--- a/src/plugins/Core/plugins/preview.py
+++ b/src/plugins/Core/plugins/preview.py
@@ -19,7 +19,10 @@ import asyncio
 import os.path
 from urllib.parse import urlparse
 
-class AccessDenied(Exception): pass
+
+class AccessDenied(Exception):
+    pass
+
 
 def check_url_protocol(url):
     parsed_url = urlparse(url)
@@ -148,13 +151,7 @@ async def preview_website(event: MessageEvent, message: Message = CommandArg()):
     except FinishedException:
         raise FinishedException()
     except AccessDenied:
-        await finish(
-            "preview.access_denied",
-            [],
-            event.user_id,
-            False,
-            True
-        )
+        await finish("preview.access_denied", [], event.user_id, False, True)
     except BaseException:
         await _error.report(traceback.format_exc(), preview)
 

--- a/src/plugins/Core/plugins/preview.py
+++ b/src/plugins/Core/plugins/preview.py
@@ -19,9 +19,12 @@ import asyncio
 import os.path
 from urllib.parse import urlparse
 
+class AccessDenied(Exception): pass
 
 def check_url_protocol(url):
     parsed_url = urlparse(url)
+    if parsed_url.scheme == "file":
+        raise AccessDenied
     return bool(parsed_url.scheme)
 
 
@@ -144,6 +147,14 @@ async def preview_website(event: MessageEvent, message: Message = CommandArg()):
 
     except FinishedException:
         raise FinishedException()
+    except AccessDenied:
+        await finish(
+            "preview.access_denied",
+            [],
+            event.user_id,
+            False,
+            True
+        )
     except BaseException:
         await _error.report(traceback.format_exc(), preview)
 


### PR DESCRIPTION
在 Preview 中，禁止用户访问 `file` 协议内容

当用户访问 `file://` 开头的 URL 时，会收到「拒绝访问」提示

