### PR TITLE
[add] 在帮助添加指令头提示

### DIFF
--- a/src/plugins/Core/lang/zh_hans.json
+++ b/src/plugins/Core/lang/zh_hans.json
@@ -6,7 +6,6 @@
   "lang.lang_author": "维护者：{}",
   "lang.compatibility": "兼容性：{} / {} {}%",
   "cave.error_to_download_images": "投稿失败：下载图片时发生错误，请稍后重试",
-  "help.tips": "指令前缀：{}\n「<...>」为必要参数\n「[...]」为可选参数\n「{...|....}」为选择参数（需在给出的选项中选择）\n发送「/? <想要执行的操作或命令>」使用 GPTCommandHelp",
   "lang.keylost": "缺失键：{}",
   "lang.empty": "请使用 {} 设置语言",
   "lang.success": "成功设置语言为 {} ",
@@ -35,12 +34,6 @@
   "forward._user": "用户：",
   "forward.group": "「群消息转发」",
   "forward._group": "群聊：",
-  
-  "_help.name": "命令列表",
-  "_help.command": "使用 /help <命令> 获取更多信息",
-  "_help.info": "说明：{}",
-  "_help.usage": "用法（{}）：\n{}",
-  "_help.unknown": "未知指令：{}",
 
   "help.list": "命令列表 —— XDbot2\n{}\n使用 {}help <命令> 获取更多信息",
   "help.list_item": "[{}] {}: {}",
@@ -49,6 +42,7 @@
   "help.copyright": "「版权声明」\nXDbot2 由 IT Craft Development Team (https://itcdt.top) 开发，基于 MIT 许可证开源",
   "help.info": "[{}] {}: {}\n\n用法: \n{}",
   "help.unknown_command": "未知指令: {}",
+  "help.command_start": "「温馨提示」\n所有命令都需要前缀[{}], 例如查询今日人品时, 您需要发送[{}jrrp]而不是仅发送[jrrp]",
 
   "jrrp.notice": "开始使用「今日人品」即代表您已阅读并同意《XDbot2「今日人品」用户协议》（https://github.com/ITCraftDevelopmentTeam/XDbot2/discussions/468）。祝您玩得开心！",
   "jrrp.new_record": "个人最高记录已刷新",

--- a/src/plugins/Core/plugins/_utils.py
+++ b/src/plugins/Core/plugins/_utils.py
@@ -33,7 +33,7 @@ def create_command(cmd: str, aliases: set = set(), **kwargs):
             bot: Bot, event: MessageEvent, message: Message = CommandArg()
         ):
             try:
-                logger.info(f"事件处理模块: {func.__module__}")
+                logger.info(f"处理模块: {func.__module__}")
                 await func(bot, event, message)
             except:
                 await error.report()

--- a/src/plugins/Core/plugins/github.py
+++ b/src/plugins/Core/plugins/github.py
@@ -167,7 +167,7 @@ async def get_issue(matcher: Matcher, event: MessageEvent):
             f"https://api.github.com/repos/{repo}/issues/{issue_id}"
         )
         labels = ""
-        for label in issue_data["labels"]:
+        for label in issue_data["labels"] or []:
             labels += f"{label['name']}, "
         await matcher.finish(
             _lang.text(

--- a/src/plugins/Core/plugins/help.py
+++ b/src/plugins/Core/plugins/help.py
@@ -52,7 +52,7 @@ async def get_help_list(bot: Bot, event: MessageEvent) -> None:
                 event.user_id,
             ),
             lang.text("help.command_status", [], event.user_id),
-            lang.text("help.command_start", [command_start]*2, event.user_id),
+            lang.text("help.command_start", [command_start] * 2, event.user_id),
             lang.text("help.eula", [], event.user_id),
             lang.text("help.copyright", [], event.user_id),
         ],

--- a/src/plugins/Core/plugins/help.py
+++ b/src/plugins/Core/plugins/help.py
@@ -52,6 +52,7 @@ async def get_help_list(bot: Bot, event: MessageEvent) -> None:
                 event.user_id,
             ),
             lang.text("help.command_status", [], event.user_id),
+            lang.text("help.command_start", [command_start]*2, event.user_id),
             lang.text("help.eula", [], event.user_id),
             lang.text("help.copyright", [], event.user_id),
         ],


### PR DESCRIPTION
[add] 增加指令头提示

这次提交添加了一个新的指令头提示，用于提醒用户在使用命令时需要使用特定的前缀。此更改的目的是为了解决在查询今日人品时，用户只发送命令而不带前缀导致无法正常工作的问题。现在，用户需要发送特定的前缀来执行相应的操作。这将提高用户体验，并确保命令的准确性和可靠性。

这个更改在 "zh_hans.json" 和 "help.py" 文件中进行了修改。