### PR TITLE
[fix] GH Issue 解析在没有 Labels 时报错

### DIFF
--- a/src/plugins/Core/plugins/_utils.py
+++ b/src/plugins/Core/plugins/_utils.py
@@ -33,7 +33,7 @@ def create_command(cmd: str, aliases: set = set(), **kwargs):
             bot: Bot, event: MessageEvent, message: Message = CommandArg()
         ):
             try:
-                logger.info(f"事件处理模块: {func.__module__}")
+                logger.info(f"处理模块: {func.__module__}")
                 await func(bot, event, message)
             except:
                 await error.report()

--- a/src/plugins/Core/plugins/github.py
+++ b/src/plugins/Core/plugins/github.py
@@ -167,7 +167,7 @@ async def get_issue(matcher: Matcher, event: MessageEvent):
             f"https://api.github.com/repos/{repo}/issues/{issue_id}"
         )
         labels = ""
-        for label in (issue_data["labels"] or []):
+        for label in issue_data["labels"] or []:
             labels += f"{label['name']}, "
         await matcher.finish(
             _lang.text(

--- a/src/plugins/Core/plugins/github.py
+++ b/src/plugins/Core/plugins/github.py
@@ -167,7 +167,7 @@ async def get_issue(matcher: Matcher, event: MessageEvent):
             f"https://api.github.com/repos/{repo}/issues/{issue_id}"
         )
         labels = ""
-        for label in issue_data["labels"]:
+        for label in (issue_data["labels"] or []):
             labels += f"{label['name']}, "
         await matcher.finish(
             _lang.text(


### PR DESCRIPTION
Fixes #545

[修复] 修正 GitHub 问题解析时没有标签导致的错误

当解析 GitHub 问题时，如果问题没有标签，报错的问题已经修复。此修复确保了在没有标签的情况下能够正常解析问题。修复了问题编号 #545。

对于似有仓库似乎还是有点问题

不理他了