### PR TITLE
[fix] 重命名json2items模块中的rubbish引用

### DIFF
--- a/src/plugins/Core/plugins/etm/json2items.py
+++ b/src/plugins/Core/plugins/etm/json2items.py
@@ -1,7 +1,7 @@
 from .json2items import mystery_box
 from .item import Item
 from .item_list import ITEMS
-from .json2items import rubbish
+from .items import rubbish
 
 
 def json2items(items, user_id=None) -> list[Item]:


### PR DESCRIPTION
这个提交将json2items模块中的rubbish引用更名为items。这个更改可能是为了与其他模块保持一致，或修复了一个命名冲突问题。