### PR TITLE
[remove] 删除上传日志功能和相关代码

### DIFF
--- a/src/plugins/Core/disabled_plugins/upload_logger.py
+++ b/src/plugins/Core/disabled_plugins/upload_logger.py
@@ -1,9 +1,9 @@
 from nonebot import on_command
 from nonebot.adapters.onebot.v11 import GroupMessageEvent, Bot
-from . import _lang
+from ..plugins import _lang
 import os.path
 import traceback
-from . import _error
+from ..plugins import _error
 
 upload_log = on_command("upload-log", aliases={"上传日志"})
 


### PR DESCRIPTION
之前的功能模块"upload_logger.py"被删除了。这个模块主要用于在群组消息中处理上传日志的命令，将错误日志上传到群组。然而，这个功能被认为不再需要，并因此被移除。这个变动不会对现有的功能和特性产生任何重大影响。