### PR TITLE
修复 Gpt Scale 的定时任务无法使用的问题

### DIFF
--- a/src/plugins/Core/plugins/gpt_scale.py
+++ b/src/plugins/Core/plugins/gpt_scale.py
@@ -38,7 +38,8 @@ async def _(
 
 @scheduler.scheduled_job("cron", hour="0", minute="0", second="0", id="scale_sessions")
 async def scale_sessions() -> None:
-    for session_id in os.listdir("data/gpt/sessions"):
+    for session_file in os.listdir("data/gpt/sessions"):
+        session_id = session_file[:-5]
         if len(get_session_messages(session_id)) < 5:
             continue
         await scale_session(session_id)


### PR DESCRIPTION
定时任务无法正确读取和保存 Gpt Scale 所使用的会话内容。修复了该问题，使得定时任务能够正常读取和保存会话。这确保了会话内容的准确性和一致性。

> 下次改 ChatGPTv2 记得提醒我会话 ID 要去掉 .json